### PR TITLE
Correct SideOnly

### DIFF
--- a/src/exterminatorJeff/undergroundBiomes/common/block/BlockAnthracite.java
+++ b/src/exterminatorJeff/undergroundBiomes/common/block/BlockAnthracite.java
@@ -3,6 +3,8 @@ package exterminatorJeff.undergroundBiomes.common.block;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.util.Icon;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import exterminatorJeff.undergroundBiomes.common.UndergroundBiomes;
 
 public class BlockAnthracite extends Block{
@@ -16,11 +18,13 @@ public class BlockAnthracite extends Block{
 	
 	private Icon texture;
 	
+	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerIcons(IconRegister iconRegister){
     	texture = iconRegister.registerIcon(UndergroundBiomes.texturePath + "anthracite");
     }
 	
+	@SideOnly(Side.CLIENT)
 	@Override
 	public Icon getIcon(int side, int metadata){
 		return texture;

--- a/src/exterminatorJeff/undergroundBiomes/common/block/BlockIgneousStoneSlab.java
+++ b/src/exterminatorJeff/undergroundBiomes/common/block/BlockIgneousStoneSlab.java
@@ -9,6 +9,8 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Icon;
 import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import exterminatorJeff.undergroundBiomes.common.UndergroundBiomes;
 
 public class BlockIgneousStoneSlab extends BlockStep{
@@ -53,6 +55,7 @@ public class BlockIgneousStoneSlab extends BlockStep{
 		return metadata;
 	}
     
+    @SideOnly(Side.CLIENT)
     @Override
     public Icon getIcon(int par1, int par2)
     {
@@ -82,6 +85,7 @@ public class BlockIgneousStoneSlab extends BlockStep{
         return ret;
     }
     
+	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerIcons(IconRegister iconRegister){
     	for(int i = 0; i < 8; i++){

--- a/src/exterminatorJeff/undergroundBiomes/common/block/BlockMetadataBase.java
+++ b/src/exterminatorJeff/undergroundBiomes/common/block/BlockMetadataBase.java
@@ -17,6 +17,7 @@ public class BlockMetadataBase extends Block{
 		
 	}
 	
+	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerIcons(IconRegister iconRegister){
     	for(int i = 0; i < 8; i++){

--- a/src/exterminatorJeff/undergroundBiomes/common/item/ItemBlockBase.java
+++ b/src/exterminatorJeff/undergroundBiomes/common/item/ItemBlockBase.java
@@ -4,6 +4,8 @@ import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Icon;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import exterminatorJeff.undergroundBiomes.common.UndergroundBiomes;
 
 public class ItemBlockBase extends ItemBlock {
@@ -15,6 +17,7 @@ public class ItemBlockBase extends ItemBlock {
 		
 	}
 	
+	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerIcons(IconRegister iconRegister){
     	for(int i = 0; i < 8; i++){

--- a/src/exterminatorJeff/undergroundBiomes/common/item/ItemIgneousStoneSlab.java
+++ b/src/exterminatorJeff/undergroundBiomes/common/item/ItemIgneousStoneSlab.java
@@ -10,7 +10,6 @@ import net.minecraft.util.Icon;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import exterminatorJeff.undergroundBiomes.common.UndergroundBiomes;
-import extrabiomes.module.fabrica.block.ItemRedRockSlab;
 
 public class ItemIgneousStoneSlab extends ItemSlab{
 	

--- a/src/exterminatorJeff/undergroundBiomes/common/item/ItemLigniteCoal.java
+++ b/src/exterminatorJeff/undergroundBiomes/common/item/ItemLigniteCoal.java
@@ -3,6 +3,8 @@ package exterminatorJeff.undergroundBiomes.common.item;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.util.Icon;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import exterminatorJeff.undergroundBiomes.common.UndergroundBiomes;
 
 public class ItemLigniteCoal extends Item{
@@ -15,15 +17,18 @@ public class ItemLigniteCoal extends Item{
 		// TODO Auto-generated constructor stub
 	}
 	
+	@SideOnly(Side.CLIENT)
 	public String getTextureFile(){
 		return UndergroundBiomes.itemTextures;
 	}
 	
+	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerIcons(IconRegister iconRegister){
 		texture = iconRegister.registerIcon(UndergroundBiomes.texturePath + "lignite");
 	}
 	
+	@SideOnly(Side.CLIENT)
 	@Override
 	public Icon getIconFromDamage(int damage){
 		return texture;


### PR DESCRIPTION
Leaving out client-only functions without SideOnly may crash while loading the dedicated server, especially if mods are inspecting all available classes/methods (like [mine](https://github.com/grompe/moreeverything))
